### PR TITLE
Fix psy/psysh require version to be compatible with leafs/aloe

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		}
 	],
 	"require": {
-		"psy/psysh": "^0.9.9",
+		"psy/psysh": "^0.10.0",
 		"symfony/console": "^5.0",
 		"symfony/process": "^5.0",
 		"phpunit/phpunit": "^9.0",


### PR DESCRIPTION
<!--
	Please only send a pull request to branches which are currently supported: https://leafphp.dev/community/contributing.html#pull-request-guidelines

	Pull requests without a descriptive title, thorough description, or tests will be closed.
-->

## Description
- Changed require version from ^0.9.9 to ^0.10.0 so that alchemy is compatible with leafs/aloe in MVC that requires version ^0.10.9
<!--
	Describe your changes in detail. In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

## Related Issue
Issue mentioned on discord leaf-mvc channel

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->